### PR TITLE
Add basic working profile for onioncircuits

### DIFF
--- a/profiles/onioncircuits.json
+++ b/profiles/onioncircuits.json
@@ -1,0 +1,22 @@
+{
+"name": "onioncircuits"
+, "path": "/usr/bin/onioncircuits"
+, "_watchdog": ["onioncircuits"]
+, "xserver": {
+	"enabled": true
+	, "enable_tray": false
+}
+, "networking":{
+	"type": "empty"
+	, "sockets": [
+		{"type": "client", "proto": "tcp", "port": 9050}
+	    , {"type": "client", "proto": "tcp2unix", "port": 9051, "destination": "/var/run/roflcoptor/onioncircuits.socket"}
+	]
+}
+, "whitelist": []
+, "environment": []
+, "seccomp": {
+	"mode": "blacklist"
+	, "enforce": true
+}
+}


### PR DESCRIPTION

I've tested this profile and it works, however it requires Leif's patch to roflcoptor and bulb as detailed in his pull request: https://github.com/subgraph/roflcoptor/pull/45

Before we merge this pull request we must either wait for Yawning to merge Leif's bulb patch or we can fork bulb and use that instead.