### PR TITLE
oz/seccomp indexes an array out of bounds when no args are provided

### DIFF
--- a/oz-seccomp/seccomp.go
+++ b/oz-seccomp/seccomp.go
@@ -37,14 +37,16 @@ func Main() {
 	flag.Parse()
 
 	args := flag.Args()
-	cmdArgs := []string{args[0]}
-
-	var settings seccomp.SeccompSettings
 
 	if len(args) < 1 {
 		log.Error("oz-seccomp: no command.")
 		os.Exit(1)
 	}
+
+	cmdArgs := []string{args[0]}
+
+	var settings seccomp.SeccompSettings
+
 
 	cmd := args[0]
 	cmdArgs = args


### PR DESCRIPTION
```
➜  ~ $GOPATH/bin/oz-seccomp
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/subgraph/oz/oz-seccomp.Main()
        /usr/local/opt/go/libexec/bin/src/github.com/subgraph/oz/oz-seccomp/seccomp.go:40 +0x1ea3
main.main()
        /usr/local/opt/go/libexec/bin/src/github.com/subgraph/oz/cmd/oz-seccomp/main.go:8 +0x20
```
The length of the arg checks happens after it attempts to grab the first arg.